### PR TITLE
add the Covid-19 Public Data Collaboration Project

### DIFF
--- a/_data/global.yml
+++ b/_data/global.yml
@@ -220,7 +220,13 @@
     content: data visualization, simple short-term prediction per country
     tags:
     - analysis
-
+  - repo_name: https://renkulab.io/gitlab/covid-19/covid-19-public-data
+    web_name: renku_covid
+    web_url: https://renkulab.io/projects/covid-19/covid-19-public-data
+    content: Collaborative project collecting data and analysis with built-in interactive compute environments.
+    tags:
+    - analysis
+    - data
 
 # others
   - repo_name: brentjackson/OpenIntubator

--- a/_data/global.yml
+++ b/_data/global.yml
@@ -220,9 +220,10 @@
     content: data visualization, simple short-term prediction per country
     tags:
     - analysis
-  - repo_name: https://renkulab.io/gitlab/covid-19/covid-19-public-data
-    web_name: renku_covid
-    web_url: https://renkulab.io/projects/covid-19/covid-19-public-data
+  - web_name: gitlab/covid-19/covid-19-public-data
+    web_url: https://renkulab.io/gitlab/covid-19/covid-19-public-data
+    web2_name: renku_covid project page
+    web2_url: https://renkulab.io/projects/covid-19/covid-19-public-data
     content: Collaborative project collecting data and analysis with built-in interactive compute environments.
     tags:
     - analysis


### PR DESCRIPTION
Adds an entry for the "Covid-19 Public Data Collaboration Project" run on the renku platform. 