### PR TITLE
edit renku information

### DIFF
--- a/_data/global.yml
+++ b/_data/global.yml
@@ -224,10 +224,8 @@
     content: data visualization, simple short-term prediction per country
     tags:
     - analysis
-  - web_name: gitlab/covid-19/covid-19-public-data
-    web_url: https://renkulab.io/gitlab/covid-19/covid-19-public-data
-    web2_name: renku_covid project page
-    web2_url: https://renkulab.io/projects/covid-19/covid-19-public-data
+  - web_name: renku_covid project page
+    web_url: https://renkulab.io/projects/covid-19/covid-19-public-data
     content: Collaborative project collecting data and analysis with built-in interactive compute environments.
     tags:
     - analysis


### PR DESCRIPTION
The link should ideally go straight to the renkulab.io page, not gitlab. 